### PR TITLE
Hotfix Omega: Fix message communication with V2X Hub and CARMA Messenger

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CARMA 1tenth Vehicle to Everything
 
-This repo provides code for the CARMA 1tenth (C1T) Vehicle to Everything (V2X) radio emulator (C1T2X) on a Raspberry Pi 4B+.
+c1t2x-emulator is a new repository that enables Raspberry Pi’s to act as mock Onboard Units (OBUs) and Roadside Units (RSUs) for the C1T platform. This includes the ability to communicate with vehicles and V2X Hub instances, as well as forwarding messages over WiFi to other Raspberry Pi’s. This repo provides code for the CARMA 1tenth (C1T) Vehicle to Everything (V2X) radio emulator (C1T2X) on a Raspberry Pi 4B+.
 
 ## Python requirements
 This package requires the following three python packages:
@@ -75,3 +75,20 @@ crontab -e
 # Add this line to the end
 @reboot python /bin/C1T2X_OBU.py &
 ```
+
+## Contribution
+Welcome to the CARMA contributing guide. Please read this guide to learn about our development process, how to propose pull requests and improvements, and how to build and test your changes to this project. [CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
+
+## Code of Conduct 
+Please read our [CARMA Code of Conduct](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Code_of_Conduct.md) which outlines our expectations for participants within the CARMA community, as well as steps to reporting unacceptable behavior. We are committed to providing a welcoming and inspiring community for all and expect our code of conduct to be honored. Anyone who violates this code of conduct may be banned from the community.
+
+## Attribution
+The development team would like to acknowledge the people who have made direct contributions to the design and code in this repository. [CARMA Attribution](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/ATTRIBUTION.txt) 
+
+## License
+By contributing to the Federal Highway Administration (FHWA) Connected Automated Research Mobility Applications (CARMA), you agree that your contributions will be licensed under its Apache License 2.0 license. [CARMA License](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/docs/License.md) 
+
+## Contact
+Please click on the CARMA logo below to visit the Federal Highway Adminstration(FHWA) CARMA website.
+
+[![CARMA Image](https://raw.githubusercontent.com/usdot-fhwa-stol/carma-platform/develop/docs/image/CARMA_icon.png)](https://highways.dot.gov/research/research-programs/operations/CARMA)

--- a/src/C1T2X_OBU.py
+++ b/src/C1T2X_OBU.py
@@ -186,6 +186,8 @@ def LAN_listening_thread():
 		error = True
 		c1t2x_logger.info("Terminating LAN Thread")
 
+# Removes unnecessary RSU header information
+# Source: https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/engineering_tools/msgIntersect.py
 def strip_header(packet):
     data = packet.decode('ascii')
     idx = data.find("Payload=")

--- a/src/C1T2X_OBU.py
+++ b/src/C1T2X_OBU.py
@@ -20,6 +20,7 @@ from ruamel.yaml import YAML
 from threading import Thread, Lock
 from pathlib import Path, PurePath
 import argparse
+from binascii import unhexlify
 
 from Networking.networking import UDP_NET
 
@@ -121,7 +122,7 @@ def sendVANET(vPacket):
 
 def sendLAN(lPacket):
 	global lan
-	lan.send_data(lPacket)
+	lan.send_data(strip_header(lPacket))
 
 def VANET_listening_thread():
 	global error
@@ -184,6 +185,13 @@ def LAN_listening_thread():
 	with mutex:
 		error = True
 		c1t2x_logger.info("Terminating LAN Thread")
+
+def strip_header(packet):
+    data = packet.decode('ascii')
+    idx = data.find("Payload=")
+    payload = data[idx+8:-1]
+    encoded = payload.encode('utf-8')
+    return unhexlify(encoded)
 
 def main():
 

--- a/src/config/params.yaml
+++ b/src/config/params.yaml
@@ -20,7 +20,7 @@ loop_time: 1e-07
 print_data: False
 
 # String:
-logging_level: 'WARN'
+logging_level: 'DEBUG'
 
 # Boolean: Decode incoming LAN packet
 LAN_DECODE: False


### PR DESCRIPTION
# PR Details
## Description
Message communication between the Raspberry Pi RSU/OBUs had untracked changes that are required for properly forwarding messages to V2X Hub and CARMA Messenger. This PR includes these necessary changes.

## Related GitHub Issue

NA

## Related Jira Key

[CF-935](https://usdot-carma.atlassian.net/browse/CF-935)

## Motivation and Context

The C1T mock OBU/RSUs need to communicate with V2X Hub and CARMA Messenger to coordinate automated Port Drayage.

## How Has This Been Tested?

Tested on the C1T trucks in the garage with all necessary local changes commited.

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


[CF-935]: https://usdot-carma.atlassian.net/browse/CF-935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ