### PR TITLE
Hotfix Omega: Fix message communication with V2X Hub and CARMA Messenger

### DIFF
--- a/src/C1T2X_OBU.py
+++ b/src/C1T2X_OBU.py
@@ -186,6 +186,8 @@ def LAN_listening_thread():
 		error = True
 		c1t2x_logger.info("Terminating LAN Thread")
 
+# Removes unnecessary RSU header information
+# Source: https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/engineering_tools/msgIntersect.py
 def strip_header(packet):
     data = packet.decode('ascii')
     idx = data.find("Payload=")

--- a/src/C1T2X_OBU.py
+++ b/src/C1T2X_OBU.py
@@ -20,6 +20,7 @@ from ruamel.yaml import YAML
 from threading import Thread, Lock
 from pathlib import Path, PurePath
 import argparse
+from binascii import unhexlify
 
 from Networking.networking import UDP_NET
 
@@ -121,7 +122,7 @@ def sendVANET(vPacket):
 
 def sendLAN(lPacket):
 	global lan
-	lan.send_data(lPacket)
+	lan.send_data(strip_header(lPacket))
 
 def VANET_listening_thread():
 	global error
@@ -184,6 +185,13 @@ def LAN_listening_thread():
 	with mutex:
 		error = True
 		c1t2x_logger.info("Terminating LAN Thread")
+
+def strip_header(packet):
+    data = packet.decode('ascii')
+    idx = data.find("Payload=")
+    payload = data[idx+8:-1]
+    encoded = payload.encode('utf-8')
+    return unhexlify(encoded)
 
 def main():
 

--- a/src/config/params.yaml
+++ b/src/config/params.yaml
@@ -20,7 +20,7 @@ loop_time: 1e-07
 print_data: False
 
 # String:
-logging_level: 'WARN'
+logging_level: 'DEBUG'
 
 # Boolean: Decode incoming LAN packet
 LAN_DECODE: False


### PR DESCRIPTION
# PR Details
## Description
Message communication between the Raspberry Pi RSU/OBUs had untracked changes that are required for properly forwarding messages to V2X Hub and CARMA Messenger. This PR includes these necessary changes.

## Related GitHub Issue

NA

## Related Jira Key

[CF-935](https://usdot-carma.atlassian.net/browse/CF-935)

## Motivation and Context

The C1T mock OBU/RSUs need to communicate with V2X Hub and CARMA Messenger to coordinate automated Port Drayage.

## How Has This Been Tested?

Tested on the C1T trucks in the garage with all necessary local changes commited.

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


[CF-935]: https://usdot-carma.atlassian.net/browse/CF-935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ