### PR TITLE
Cf 935 fix comms

### DIFF
--- a/src/C1T2X_OBU.py
+++ b/src/C1T2X_OBU.py
@@ -186,6 +186,8 @@ def LAN_listening_thread():
 		error = True
 		c1t2x_logger.info("Terminating LAN Thread")
 
+# Removes unnecessary RSU header information
+# Source: https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/engineering_tools/msgIntersect.py
 def strip_header(packet):
     data = packet.decode('ascii')
     idx = data.find("Payload=")

--- a/src/C1T2X_OBU.py
+++ b/src/C1T2X_OBU.py
@@ -20,6 +20,7 @@ from ruamel.yaml import YAML
 from threading import Thread, Lock
 from pathlib import Path, PurePath
 import argparse
+from binascii import unhexlify
 
 from Networking.networking import UDP_NET
 
@@ -121,7 +122,7 @@ def sendVANET(vPacket):
 
 def sendLAN(lPacket):
 	global lan
-	lan.send_data(lPacket)
+	lan.send_data(strip_header(lPacket))
 
 def VANET_listening_thread():
 	global error
@@ -184,6 +185,13 @@ def LAN_listening_thread():
 	with mutex:
 		error = True
 		c1t2x_logger.info("Terminating LAN Thread")
+
+def strip_header(packet):
+    data = packet.decode('ascii')
+    idx = data.find("Payload=")
+    payload = data[idx+8:-1]
+    encoded = payload.encode('utf-8')
+    return unhexlify(encoded)
 
 def main():
 

--- a/src/config/params.yaml
+++ b/src/config/params.yaml
@@ -20,7 +20,7 @@ loop_time: 1e-07
 print_data: False
 
 # String:
-logging_level: 'WARN'
+logging_level: 'DEBUG'
 
 # Boolean: Decode incoming LAN packet
 LAN_DECODE: False


### PR DESCRIPTION
# PR Details
## Description

This PR includes logic to exchange acks between the Raspberry Pi OBU/RSUs when a message is received. The behavior for the sender/receiver is:

Sender:
1. Receives message over LAN
2. Sends message over WiFi
3. Sleeps for 1 second while waiting for an ack
4. If an ack was received, exit. Else, go back to 2

Receiver:
1. Receives message over WiFi
2. If this message matches the previously received message, skip to 4 (an ack was likely dropped, which is why a duplicate message was sent)
3. Sends message over LAN
4. Sends an ack over WiFi

## Related GitHub Issue
NA

## Related Jira Key
[CF-928](https://usdot-carma.atlassian.net/browse/CF-928)

## Motivation and Context

Packets dropping between the Raspberry Pi OBU/RSUs have caused the C1T vehicle to halt while waiting for a message it will never receive. This PR addresses this issue by ensuring that if packets are ever dropped, the OBU/RSU will rebroadcast its message until the other device acknowledges that it has been received.

## How Has This Been Tested?

Three different tests were run:
1. While running the port drayage demo, the OBU was rebooted while the vehicle was stopped at the dropoff location. The operator then clicked through the prompts to complete the dropoff. Since the OBU was still rebooting, the RSU did not receive acknowledgement that the OBU had received the message to proceed to the next pickup location, and thus kept attempting to broadcast the message. Once the OBU finished rebooting, it eventually received the message and continued to the pickup point.
2. A similar test was run, except the RSU was rebooted while the vehicle was driving. Once it arrived to its destination, it could not broadcast its arrival message to the RSU until it finished rebooting. After the RSU finished rebooting, it eventually received the arrival message that the OBU was continuously broadcasting. The vehicle then carried on and completed the rest of the demo
3. V2X Hub was configured to let the vehicle continuously loop. The vehicle drove for over 30 minutes with over 180 stops and did not halt due to packet drops. The vehicle logs showed multiple instances where packets were dropped and the vehicle or V2X Hub had to rebroadcast its message, but the demonstration still continued.

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


[CF-928]: https://usdot-carma.atlassian.net/browse/CF-928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ