### PR TITLE
Cf 928 ack exchange

### DIFF
--- a/src/C1T2X_OBU.py
+++ b/src/C1T2X_OBU.py
@@ -58,6 +58,9 @@ c1t2x_logger.info("\n---------------------------\nStarting C1T2X OBU Logger\n---
 # Initialize error
 error = False
 
+# Initialize waiting for ack
+waiting_for_ack = False
+
 # Sets printData bool to cmd line arg
 printData = args.print
 
@@ -125,8 +128,8 @@ def sendLAN(lPacket):
 	lan.send_data(strip_header(lPacket))
 
 def VANET_listening_thread():
-	global error
-
+	global error, waiting_for_ack
+	previous_packet_received = ""
 	while not vanet.error:
 		with mutex:
 			if error:
@@ -137,7 +140,22 @@ def VANET_listening_thread():
 			c1t2x_logger.debug("Received %s from VANET", pkt)
 			if pkt:
 				if not parseVANETPacket:
-					sendLAN(pkt[0])
+					# Check if ack or payload
+					data = pkt[0].decode('utf-8')
+					if data == "1":  # Ack
+						with mutex:
+							wait_for_ack = False
+						c1t2x_logger.info("Received ack")
+					elif data == previous_packet_received:  # Duplicate message received, so just resend ack
+						ack = b"1"
+						sendVANET(ack)
+						c1t2x_logger.info("Received duplicate message, resending ack")
+					else:  # New message received, forward it to LAN and send ack
+						ack = b"1"
+						sendVANET(ack)
+						sendLAN(pkt[0])
+						previous_packet_received = pkt[0]
+						c1t2x_logger.info("Received new message, sent ack")
 				else:
 					# feature to parse incoming VANET message is not yet enabled
 					c1t2x_logger.error("Feature to parse incoming VANET message is not yet enabled")
@@ -156,7 +174,7 @@ def VANET_listening_thread():
 		c1t2x_logger.info("Terminating VANET Thread")
 
 def LAN_listening_thread():
-	global error
+	global error, waiting_for_ack
 
 	while not lan.error:
 		with mutex:
@@ -169,6 +187,18 @@ def LAN_listening_thread():
 			if pkt:
 				if not parseLANPacket:
 					sendVANET(pkt[0])
+					# Wait for ack
+					waiting_for_ack = True
+					c1t2x_logger.info("Message sent, waiting for ack")
+					time.sleep(1.0)
+					while True:
+						with mutex:
+							if waiting_for_ack:
+								sendVANET(pkt[0])
+								c1t2x_logger.info("Still waiting for ack")
+							else:
+								break
+						time.sleep(1.0)
 				else:
 					# feature to parse incoming LAN packet is not enabled
 					# this feature may be used for things like responding to requests from the LAN connection, etc.

--- a/src/C1T2X_OBU.py
+++ b/src/C1T2X_OBU.py
@@ -199,7 +199,7 @@ def LAN_listening_thread():
 								break
 						time.sleep(1.0)
                     if waiting_for_ack:
-                        print("Ack was never received")
+                        raise Exception("Ack was never received")
 				else:
 					# feature to parse incoming LAN packet is not enabled
 					# this feature may be used for things like responding to requests from the LAN connection, etc.

--- a/src/C1T2X_OBU.py
+++ b/src/C1T2X_OBU.py
@@ -145,7 +145,7 @@ def VANET_listening_thread():
 					data = pkt[0].decode('utf-8')
 					if data == "1":  # Ack
 						with mutex:
-							wait_for_ack = False
+							waiting_for_ack = False
 						c1t2x_logger.info("Received ack")
 					elif data == previous_packet_received:  # Duplicate message received, so just resend ack
 						sendVANET(ack)

--- a/src/C1T2X_OBU.py
+++ b/src/C1T2X_OBU.py
@@ -198,8 +198,8 @@ def LAN_listening_thread():
 							else:
 								break
 						time.sleep(1.0)
-                    if waiting_for_ack:
-                        raise Exception("Ack was never received")
+                    			if waiting_for_ack:
+                        			raise Exception("Ack was never received")
 				else:
 					# feature to parse incoming LAN packet is not enabled
 					# this feature may be used for things like responding to requests from the LAN connection, etc.

--- a/src/C1T2X_OBU.py
+++ b/src/C1T2X_OBU.py
@@ -198,8 +198,8 @@ def LAN_listening_thread():
 							else:
 								break
 						time.sleep(1.0)
-                    			if waiting_for_ack:
-                        			raise Exception("Ack was never received")
+					if waiting_for_ack:
+						raise Exception("Ack was never received")
 				else:
 					# feature to parse incoming LAN packet is not enabled
 					# this feature may be used for things like responding to requests from the LAN connection, etc.


### PR DESCRIPTION
# PR Details
## Description

This PR includes logic to exchange acks between the Raspberry Pi OBU/RSUs when a message is received. The behavior for the sender/receiver is:

Sender:
1. Receives message over LAN
2. Sends message over WiFi
3. Sleeps for 1 second while waiting for an ack
4. If an ack was received, exit. Else, go back to 2

Receiver:
1. Receives message over WiFi
2. If this message matches the previously received message, skip to 4 (an ack was likely dropped, which is why a duplicate message was sent)
3. Sends message over LAN
4. Sends an ack over WiFi

## Related GitHub Issue
NA

## Related Jira Key
[CF-928](https://usdot-carma.atlassian.net/browse/CF-928)

## Motivation and Context

Packets dropping between the Raspberry Pi OBU/RSUs have caused the C1T vehicle to halt while waiting for a message it will never receive. This PR addresses this issue by ensuring that if packets are ever dropped, the OBU/RSU will rebroadcast its message until the other device acknowledges that it has been received.

## How Has This Been Tested?

Three different tests were run:
1. While running the port drayage demo, the OBU was rebooted while the vehicle was stopped at the dropoff location. The operator then clicked through the prompts to complete the dropoff. Since the OBU was still rebooting, the RSU did not receive acknowledgement that the OBU had received the message to proceed to the next pickup location, and thus kept attempting to broadcast the message. Once the OBU finished rebooting, it eventually received the message and continued to the pickup point.
2. A similar test was run, except the RSU was rebooted while the vehicle was driving. Once it arrived to its destination, it could not broadcast its arrival message to the RSU until it finished rebooting. After the RSU finished rebooting, it eventually received the arrival message that the OBU was continuously broadcasting. The vehicle then carried on and completed the rest of the demo
3. V2X Hub was configured to let the vehicle continuously loop. The vehicle drove for over 30 minutes with over 180 stops and did not halt due to packet drops. The vehicle logs showed multiple instances where packets were dropped and the vehicle or V2X Hub had to rebroadcast its message, but the demonstration still continued.

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


[CF-928]: https://usdot-carma.atlassian.net/browse/CF-928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ