### PR TITLE
replaced c1t2x-emulator with v2x-emulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CARMA 1tenth Vehicle to Everything
 
-c1t2x-emulator is a new repository that enables Raspberry Pi’s to act as mock Onboard Units (OBUs) and Roadside Units (RSUs) for the C1T platform. This includes the ability to communicate with vehicles and V2X Hub instances, as well as forwarding messages over WiFi to other Raspberry Pi’s. This repo provides code for the CARMA 1tenth (C1T) Vehicle to Everything (V2X) radio emulator (C1T2X) on a Raspberry Pi 4B+.
+v2x-emulator is a new repository that enables Raspberry Pi’s to act as mock Onboard Units (OBUs) and Roadside Units (RSUs) for the CDA1tenth platform. This includes the ability to communicate with vehicles and V2X Hub instances, as well as forwarding messages over WiFi to other Raspberry Pi’s. This repo provides code for the CDA1tenth Vehicle to Everything (V2X) radio emulator on a Raspberry Pi 4B+.
 
 ## Python requirements
 This package requires the following three python packages:
@@ -8,31 +8,31 @@ This package requires the following three python packages:
 - [ruamel.yaml](https://pypi.org/project/ruamel.yaml/)
 - [asn1tools](https://pypi.org/project/asn1tools/)
 
-These packages can be installed by navigating to the C1T2X directory, and running:
+These packages can be installed by navigating to the V2X directory, and running:
 ```
 sudo pip install -r ./requirements.txt
 ```
 
 ## Functionality
-The C1T2X radios function similar to the DSRC radios used by CARMA Platform equipped vehicles in that they receive UDP packets from a PC and broadcast them "over the air." The radios used by the CARMA Platform are configured to be in Road Side Unit (RSU) mode where messages are forwarded, and C1T2X seeks to emulate this behavior.
+The V2X radios function similar to the DSRC radios used by CARMA Platform equipped vehicles in that they receive UDP packets from a PC and broadcast them "over the air." The radios used by the CARMA Platform are configured to be in Road Side Unit (RSU) mode where messages are forwarded, and V2X seeks to emulate this behavior.
 
-The C1T2X radios are intended to use the same driver as the full-scale CARMA vehicle's DSRC radios, specifically the [carma-cohda-dsrc-driver](https://github.com/usdot-fhwa-stol/carma-cohda-dsrc-driver).
+The V2X radios are intended to use the same driver as the full-scale CARMA vehicle's DSRC radios, specifically the [carma-cohda-dsrc-driver](https://github.com/usdot-fhwa-stol/carma-cohda-dsrc-driver).
 
-The C1T2X solution uses the WiFi band for its Vehicle Area Network (VANET) rather than Dedicated Short Range Communications (DSRC) or Cellular V2X (C-V2X). It is intended to be an educational tool used to facilitate communication and cooperation between scaled-down vehicles and infrastructure - and it not intended as a deployable solution. Public Deployment of a WiFi-based VANET is outside of the scope of the C1T project, and may be susceptible to restrictions/guidelines from the Federal Communications Commission (FCC).
+The V2X solution uses the WiFi band for its Vehicle Area Network (VANET) rather than Dedicated Short Range Communications (DSRC) or Cellular V2X (C-V2X). It is intended to be an educational tool used to facilitate communication and cooperation between scaled-down vehicles and infrastructure - and it not intended as a deployable solution. Public Deployment of a WiFi-based VANET is outside of the scope of the CDA1tenth project, and may be susceptible to restrictions/guidelines from the Federal Communications Commission (FCC).
 
-C1T2X radios are capable of running their own applications through threading - provided that message decoding/encoding and parsing is enabled.
+V2X radios are capable of running their own applications through threading - provided that message decoding/encoding and parsing is enabled.
 At this time, the radios do not decode or encode packets and function only to forward messages - similar to the full scale CARMA Platform vehicles' radios. However, further work can be done to enable this.
 
-At a high level, the C1T2X radios can:
+At a high level, the V2X radios can:
 - Receive UDP packets over the LAN from the Jetson Xavier
 - Broadcast UDP packets over the VANET to other scaled-down cooperative entities
 - Receive UDP packets over the VANET from other scaled-down cooperative entities
 - Broadcast UDP packets over the LAN to the Jetson Xavier
 
-Broadcasting over WiFi for the VANET allows for each C1T2X radio to receive its own messages that it broadcasts. The C1T2X radio checks the IP of the device that sends each message, and filters out messages that are sent from its own IP.
+Broadcasting over WiFi for the VANET allows for each V2X radio to receive its own messages that it broadcasts. The V2X radio checks the IP of the device that sends each message, and filters out messages that are sent from its own IP.
 
 ## Configuration
-The C1T2X radios are connected to both a local area network (the connection between the Pi and a Jetson Xavier NX with a crossover ethernet cable) and a wireless network (the VANET).
+The V2X radios are connected to both a local area network (the connection between the Pi and a Jetson Xavier NX with a crossover ethernet cable) and a wireless network (the VANET).
 
 The radios should be configured to work on each network by adjusting the parameters in the following two YAML files:
 1. `./src/Networking/config/LAN_params.yaml`
@@ -67,13 +67,13 @@ The returner will receive the message, and send the message back over the vanet.
 The broadcaster will receive the message, and it will compare the received copy against the originally broadcasted copy.
 
 ## Running
-Once all config files are correctly made, run the `C1T2X_OBU.py` script to start the on board unit (OBU) emulator. This can be run on boot automatically with a crontab job
+Once all config files are correctly made, run the `V2X_OBU.py` script to start the on board unit (OBU) emulator. This can be run on boot automatically with a crontab job
 
 ```
-ln -s /home/$USER/c1t_ws/src/c1t2x-emulator/src/C1T2X_OBU.py /bin/C1T2X_OBU.py
+ln -s /home/$USER/cda_ws/src/v2x-emulator/src/V2X_OBU.py /bin/V2X_OBU.py
 crontab -e
 # Add this line to the end
-@reboot python /bin/C1T2X_OBU.py &
+@reboot python /bin/V2X_OBU.py &
 ```
 
 ## Contribution

--- a/README.md
+++ b/README.md
@@ -24,15 +24,15 @@ V2X radios are capable of running their own applications through threading - pro
 At this time, the radios do not decode or encode packets and function only to forward messages - similar to the full scale CARMA Platform vehicles' radios. However, further work can be done to enable this.
 
 At a high level, the V2X radios can:
-- Receive UDP packets over the LAN from the Jetson Xavier
+- Receive UDP packets over the LAN from the connected vehicle computer
 - Broadcast UDP packets over the VANET to other scaled-down cooperative entities
 - Receive UDP packets over the VANET from other scaled-down cooperative entities
-- Broadcast UDP packets over the LAN to the Jetson Xavier
+- Broadcast UDP packets over the LAN to the connected vehicle computer
 
 Broadcasting over WiFi for the VANET allows for each V2X radio to receive its own messages that it broadcasts. The V2X radio checks the IP of the device that sends each message, and filters out messages that are sent from its own IP.
 
 ## Configuration
-The V2X radios are connected to both a local area network (the connection between the Pi and a Jetson Xavier NX with a crossover ethernet cable) and a wireless network (the VANET).
+The V2X radios are connected to both a local area network (the connection between the Pi and a vehicle computer with a crossover ethernet cable) and a wireless network (the VANET).
 
 The radios should be configured to work on each network by adjusting the parameters in the following two YAML files:
 1. `./src/Networking/config/LAN_params.yaml`

--- a/src/V2X_OBU.py
+++ b/src/V2X_OBU.py
@@ -34,7 +34,7 @@ args = parser.parse_args()
 
 
 # Logging
-c1t2x_logger = None
+v2x_logger = None
 LOGGING_LEVEL = logging.INFO
 logs_directory = PurePath.joinpath(Path.cwd(), "Logs")
 
@@ -44,16 +44,16 @@ if not os.path.exists(logs_directory):
 	os.mkdir(logs_directory, 0o775)
 
 # Setup logger with formatting
-log_filename = "c1t2x_OBU.log"
-c1t2x_logger = logging.getLogger(__name__)
-c1t2x_logger.setLevel(LOGGING_LEVEL)
-c1t2x_logger_handler = logging.FileHandler(os.path.join(logs_directory, log_filename), "w")
-c1t2x_logger_handler.setLevel(LOGGING_LEVEL)
-c1t2x_logger_formatter = logging.Formatter("[%(asctime)s.%(msecs)03d] %(levelname)s - %(message)s", datefmt= "%d-%b-%y %H:%M:%S")
-c1t2x_logger_handler.setFormatter(c1t2x_logger_formatter)
-c1t2x_logger.addHandler(c1t2x_logger_handler)
+log_filename = "v2x_OBU.log"
+v2x_logger = logging.getLogger(__name__)
+v2x_logger.setLevel(LOGGING_LEVEL)
+v2x_logger_handler = logging.FileHandler(os.path.join(logs_directory, log_filename), "w")
+v2x_logger_handler.setLevel(LOGGING_LEVEL)
+v2x_logger_formatter = logging.Formatter("[%(asctime)s.%(msecs)03d] %(levelname)s - %(message)s", datefmt= "%d-%b-%y %H:%M:%S")
+v2x_logger_handler.setFormatter(v2x_logger_formatter)
+v2x_logger.addHandler(v2x_logger_handler)
 # Start logging
-c1t2x_logger.info("\n---------------------------\nStarting C1T2X OBU Logger\n---------------------------")
+v2x_logger.info("\n---------------------------\nStarting V2X OBU Logger\n---------------------------")
 
 # Initialize error
 error = False
@@ -79,43 +79,43 @@ try:
 	loopTime = params['loop_time']
 	logLevel = params['logging_level']
 except Exception as e:
-	c1t2x_logger.error("Unable to import master yaml configs")
+	v2x_logger.error("Unable to import master yaml configs")
 	error = True
 	print("Unable to import yaml configs")
 	raise e
 
-if logLevel == 'DEBUG': c1t2x_logger.setLevel(logging.DEBUG)
-elif logLevel == 'INFO': c1t2x_logger.setLevel(logging.INFO)
-elif logLevel == 'ERROR': c1t2x_logger.setLevel(logging.ERROR)
-elif logLevel == 'WARNING': c1t2x_logger.setLevel(logging.WARNING)
+if logLevel == 'DEBUG': v2x_logger.setLevel(logging.DEBUG)
+elif logLevel == 'INFO': v2x_logger.setLevel(logging.INFO)
+elif logLevel == 'ERROR': v2x_logger.setLevel(logging.ERROR)
+elif logLevel == 'WARNING': v2x_logger.setLevel(logging.WARNING)
 else: 
-	c1t2x_logger.setLevel(logging.WARNING)
+	v2x_logger.setLevel(logging.WARNING)
 	print("Configured LOGGING LEVEL is invalid. Level is set to WARNING.")
-	c1t2x_logger.warning("Configured LOGGING LEVEL is invalid. Level is set to WARNING.")
+	v2x_logger.warning("Configured LOGGING LEVEL is invalid. Level is set to WARNING.")
 
 
 # Instantiate networks
 # LAN
 try:
-	lan = UDP_NET(CONFIG_FILE='LAN_params.yaml',logger=c1t2x_logger)
+	lan = UDP_NET(CONFIG_FILE='LAN_params.yaml',logger=v2x_logger)
 except:
 	error = True
 try:
 	lan.start_connection()
 except:
-	c1t2x_logger.warning("Not connected to a LAN interface")
+	v2x_logger.warning("Not connected to a LAN interface")
 	if printData:
 		print("Not connected to a LAN interface")
 
 # VANET
 try:
-	vanet = UDP_NET(CONFIG_FILE='VANET_params.yaml',logger=c1t2x_logger)
+	vanet = UDP_NET(CONFIG_FILE='VANET_params.yaml',logger=v2x_logger)
 except:
 	error = True
 try:
 	vanet.start_connection()
 except:
-	c1t2x_logger.warning("Not connected to a VANET interface")
+	v2x_logger.warning("Not connected to a VANET interface")
 	if printData:
 		print("Not connected to a VANET interface")
 
@@ -138,7 +138,7 @@ def VANET_listening_thread():
 
 		try:
 			pkt = vanet.recv_packets()
-			c1t2x_logger.debug("Received %s from VANET", pkt)
+			v2x_logger.debug("Received %s from VANET", pkt)
 			if pkt:
 				if not parseVANETPacket:
 					# Check if ack or payload
@@ -146,31 +146,31 @@ def VANET_listening_thread():
 					if data == "1":  # Ack
 						with mutex:
 							waiting_for_ack = False
-						c1t2x_logger.info("Received ack")
+						v2x_logger.info("Received ack")
 					elif data == previous_packet_received:  # Duplicate message received, so just resend ack
 						sendVANET(ack)
-						c1t2x_logger.info("Received duplicate message, resending ack")
+						v2x_logger.info("Received duplicate message, resending ack")
 					else:  # New message received, forward it to LAN and send ack
 						sendVANET(ack)
 						sendLAN(pkt[0])
 						previous_packet_received = pkt[0]
-						c1t2x_logger.info("Received new message, sent ack")
+						v2x_logger.info("Received new message, sent ack")
 				else:
 					# feature to parse incoming VANET message is not yet enabled
-					c1t2x_logger.error("Feature to parse incoming VANET message is not yet enabled")
+					v2x_logger.error("Feature to parse incoming VANET message is not yet enabled")
 					raise NotImplementedError
 				if printData:
 					print(pkt)
 		except:
 			if printData:
 				print("Waiting to configure LAN")
-			c1t2x_logger.info("Waiting to configure LAN")
+			v2x_logger.info("Waiting to configure LAN")
 			time.sleep(0.25)
 		time.sleep(loopTime)
 
 	with mutex:
 		error = True
-		c1t2x_logger.info("Terminating VANET Thread")
+		v2x_logger.info("Terminating VANET Thread")
 
 def LAN_listening_thread():
 	global error, waiting_for_ack
@@ -178,7 +178,7 @@ def LAN_listening_thread():
 	while not lan.error:
 		with mutex:
 			if error:
-				c1t2x_logger.info("Terminating LAN Thread")
+				v2x_logger.info("Terminating LAN Thread")
 				break
 
 		try:
@@ -188,13 +188,13 @@ def LAN_listening_thread():
 					sendVANET(pkt[0])
 					# Wait for ack
 					waiting_for_ack = True
-					c1t2x_logger.info("Message sent, waiting for ack")
+					v2x_logger.info("Message sent, waiting for ack")
 					time.sleep(1.0)
 					for i in range(120):  # Attempt to rebroadcast for 2 minutes before giving up
 						with mutex:
 							if waiting_for_ack:
 								sendVANET(pkt[0])
-								c1t2x_logger.info("Still waiting for ack")
+								v2x_logger.info("Still waiting for ack")
 							else:
 								break
 						time.sleep(1.0)
@@ -204,18 +204,18 @@ def LAN_listening_thread():
 					# feature to parse incoming LAN packet is not enabled
 					# this feature may be used for things like responding to requests from the LAN connection, etc.
 					# there is no intent for this feature to be enabled but it is being allocated space in the code
-					c1t2x_logger.error("Feature to parse incoming LAN is not enabled")
+					v2x_logger.error("Feature to parse incoming LAN is not enabled")
 					raise NotImplementedError
 		except:
 			if printData:
 				print("Waiting to configure VANET")
-			c1t2x_logger.debug("Waiting to configure VANET")
+			v2x_logger.debug("Waiting to configure VANET")
 			time.sleep(0.25)
 		time.sleep(loopTime)
 
 	with mutex:
 		error = True
-		c1t2x_logger.info("Terminating LAN Thread")
+		v2x_logger.info("Terminating LAN Thread")
 
 # Removes unnecessary RSU header information
 # Source: https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/engineering_tools/msgIntersect.py
@@ -240,25 +240,25 @@ def main():
 	threads.append(VANET_mt)
 
 	for thread in threads:
-		c1t2x_logger.debug("Starting %s", thread.name)
+		v2x_logger.debug("Starting %s", thread.name)
 		thread.daemon=True
 		thread.start()
 		time.sleep(0.2)
-	c1t2x_logger.debug("All Threads Started")
+	v2x_logger.debug("All Threads Started")
 
 	try:
 		while not error:
 			time.sleep(1)
 	except KeyboardInterrupt:
-		c1t2x_logger.critical("Keyboard Interrupt Occurred")
+		v2x_logger.critical("Keyboard Interrupt Occurred")
 	finally:
 		error = True
-		c1t2x_logger.critical("\n---------------------------\nTerminating C1T2X OBU Logger\n---------------------------")
+		v2x_logger.critical("\n---------------------------\nTerminating V2X OBU Logger\n---------------------------")
 
 # code starts here
 if __name__ == '__main__':
 
-	# print to terminal that C1T2X radio is starting up
-	print("----------------------------------------------------\nSTARTING C1T2X RADIO\n----------------------------------------------------")
+	# print to terminal that V2X radio is starting up
+	print("----------------------------------------------------\nSTARTING V2X RADIO\n----------------------------------------------------")
 	
 	main()

--- a/src/broadcaster.py
+++ b/src/broadcaster.py
@@ -173,7 +173,7 @@ def main():
 # code starts here
 if __name__ == '__main__':
 
-    # print to terminal that C1T2X radio is starting up
-    print("----------------------------------------------------\nSTARTING C1T2X RADIO\n----------------------------------------------------")
+    # print to terminal that V2X radio is starting up
+    print("----------------------------------------------------\nSTARTING V2X RADIO\n----------------------------------------------------")
     
     main()

--- a/src/returner.py
+++ b/src/returner.py
@@ -175,7 +175,7 @@ def main():
 # code starts here
 if __name__ == '__main__':
 
-    # print to terminal that C1T2X radio is starting up
-    print("----------------------------------------------------\nSTARTING C1T2X RADIO\n----------------------------------------------------")
+    # print to terminal that V2X radio is starting up
+    print("----------------------------------------------------\nSTARTING V2X RADIO\n----------------------------------------------------")
     
     main()


### PR DESCRIPTION
# PR Details
## Description

This PR replaces references to CARMA1tenth (C1T) with CDA1tenth.

## Related GitHub Issue

NA

## Related Jira Key

[CF-947](https://usdot-carma.atlassian.net/browse/CF-947)

## Motivation and Context

CDA1tenth has been chosen as the name to encapsulate the Port Drayage proof-of-concept project and the follow-on workforce development project. So, we are replacing all references to the former CARMA1tenth (C1T) project to CDA1tenth.

## How Has This Been Tested?

Tested the port drayage demo on the vehicle with all renaming changes pulled to vehicle, infrastructure, and Raspberry Pis.

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

- [ ] I have added any new packages to the sonar-scanner.properties file
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


[CF-947]: https://usdot-carma.atlassian.net/browse/CF-947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ