### PR TITLE
Added startup option with systemd and updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The radios should be configured to work on each network by adjusting the paramet
 1. `./src/Networking/config/LAN_params.yaml`
 2. `./src/Networking/config/VANET_params.yaml`
 
-The IP, Port, and Network interface for each network must be set correctly. The IP and Port that are used for the LAN network should relate to the IP and Port in the ROS2 driver's params.yaml and dsrc.cfg files from the `carma-cohda-dsrc-driver` package.
+The IP, Port, and Network interface for each network must be set correctly. The IP and Port that are used for the LAN network should relate to the IP and Port in the ROS 2 driver's params.yaml and dsrc.cfg files from the `carma-cohda-dsrc-driver` package.
 
 If the wireless and wired network interfaces are unknown, the following command will identify the available network interfaces:
 ```
@@ -51,11 +51,11 @@ The VANET IP and Port that are used should be consistent across all radios on th
 You can test a full loop of the VANET with the scripts broadcaster.py and returner.py
 
 Configure the parameter YAML files on two machines and:
-- on one machine, run:
+- On one machine, run:
 ```
 python broadcaster.py vanet
 ```
-- on the other machine, run:
+- On the other machine, run:
 ```
 python returner.py vanet
 ```
@@ -67,12 +67,31 @@ The returner will receive the message, and send the message back over the vanet.
 The broadcaster will receive the message, and it will compare the received copy against the originally broadcasted copy.
 
 ## Running
-Once all config files are correctly made, run the `V2X_OBU.py` script to start the on board unit (OBU) emulator. This can be run on boot automatically with a crontab job
+Once all config files are correctly made, run the `V2X_OBU.py` script to start the on board unit (OBU) emulator script. This can be run on boot automatically with a systemd service **OR** as a crontab job. This will need to be set up for both ends of the system to support communication between the vehicle and infrastructure and auto starting the emulator script is highly recommended.
 
+### Systemd (preferred)
+Copy both `v2x-emulator.timer` and `v2x-emulator.service` into `/usr/lib/systemd/system` and run the following commands to enable the service:
+```
+sudo systemctl daemon-reload
+sudo systemctl start v2x-emulator.timer
+```
+Check the status to verify the service is active as expected:
+```
+sudo systemctl status v2x-emulator.service
+```
+Enable the service to launch on startup if so:
+```
+sudo systemctl enable v2x-emulator.timer
+```
+
+
+### Crontab
+Link the v2x-emulator script to a /bin location:
 ```
 ln -s /home/$USER/cda_ws/src/v2x-emulator/src/V2X_OBU.py /bin/V2X_OBU.py
-crontab -e
-# Add this line to the end
+```
+Edit crontab with `crontab -e` and add the following line:
+```
 @reboot python /bin/V2X_OBU.py &
 ```
 

--- a/README.md
+++ b/README.md
@@ -38,17 +38,17 @@ The radios should be configured to work on each network by adjusting the paramet
 1. `./src/Networking/config/LAN_params.yaml`
 2. `./src/Networking/config/VANET_params.yaml`
 
-The IP, Port, and Network interface for each network must be set correctly. The IP and Port that are used for the LAN network should relate to the IP and Port in the ROS2 driver's params.yaml and dsrc.cfg files from the `v2x-ros-driver` package.
+The IP, Port, and Network interface for each network must be set correctly. The IP and Port that are used for the LAN network should relate to the IP and Port in the ROS 2 driver's params.yaml and dsrc.cfg files from the `v2x-ros-driver` package.
 
 If the wireless and wired network interfaces are unknown, the following command will identify the available network interfaces:
 ```
 basename -a /sys/class/net/*
 ```
 
-The VANET IP and Port that are used should be consistent across all radios on the VANET.
+The VANET IP and Port that are used should be consistent across all radios on the VANET if using a broadcast (.255) approach. Otherwise, the VANET IPs should point to each other.
 
 ## Testing
-You can test a full loop of the VANET with the scripts broadcaster.py and returner.py
+You can test a full loop of the VANET with the scripts broadcaster.py and returner.py to make sure that IPs are correctly assigned.
 
 Configure the parameter YAML files on two machines and:
 - On one machine, run:
@@ -70,7 +70,7 @@ The broadcaster will receive the message, and it will compare the received copy 
 Once all config files are correctly made, run the `V2X_OBU.py` script to start the on board unit (OBU) emulator script. This can be run on boot automatically with a systemd service **OR** as a crontab job. This will need to be set up for both ends of the system to support communication between the vehicle and infrastructure and auto starting the emulator script is highly recommended.
 
 ### Systemd (preferred)
-Copy both `v2x-emulator.timer` and `v2x-emulator.service` into `/usr/lib/systemd/system` and run the following commands to enable the service:
+Copy both `v2x-emulator.timer` and `v2x-emulator.service` into `/usr/lib/systemd/system` after updating the filepath to location of `v2x-emulator`. Then run the following commands to enable the service:
 ```
 sudo systemctl daemon-reload
 sudo systemctl start v2x-emulator.timer
@@ -83,10 +83,11 @@ Enable the service to launch on startup if so:
 ```
 sudo systemctl enable v2x-emulator.timer
 ```
+The boot timer can be increased to ensure the service is brought up after the system has initialized. Checking the `systemctl status` after a restart will help determine if the service has been configured with a long enough timer.
 
 
 ### Crontab
-Link the v2x-emulator script to a /bin location:
+Link the `V2X_OBU.py` script to a `/bin` location with consideration for where `v2x-emulator` is installed:
 ```
 ln -s /home/$USER/cda_ws/src/v2x-emulator/src/V2X_OBU.py /bin/V2X_OBU.py
 ```
@@ -94,6 +95,7 @@ Edit crontab with `crontab -e` and add the following line:
 ```
 @reboot python /bin/V2X_OBU.py &
 ```
+
 
 ## Contribution
 Welcome to the CARMA contributing guide. Please read this guide to learn about our development process, how to propose pull requests and improvements, and how to build and test your changes to this project. [CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md)

--- a/v2x-emulator.service
+++ b/v2x-emulator.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Service to run the v2x-emulator script
+After=syslog.target
+
+[Service]
+Type=simple
+User=ubuntu
+WorkingDirectory=/home/ubuntu/v2x-emulator
+ExecStart=/usr/bin/python3 /home/ubuntu/v2x-emulator/src/V2X_OBU.py
+Restart=on-failure
+
+StandardOutput=syslog
+StandardError=syslog
+
+[Install]
+WantedBy=default.target

--- a/v2x-emulator.timer
+++ b/v2x-emulator.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Start v2x-emulator script automatically on startup after OnBootSec timer
+
+[Timer]
+OnBootSec=20s
+Unit=v2x-emulator.service
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION

<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

The systemd process of automatically starting the V2X_OBU.py script seems to be more reliable than the previous crontab approach. Added a .service, .timer, and documentation for how to set up the script as a systemd service in addition to the previous crontab instructions.

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key

<!-- e.g. CAR-123 -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Tested on infrastructure hardware with both a laptop and Raspberry Pi 4 while part of the full CDA 1Tenth system, vehicle included.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
