### PR TITLE
CF 970 TRB Changes

### DIFF
--- a/src/Networking/config/LAN_params.yaml
+++ b/src/Networking/config/LAN_params.yaml
@@ -13,13 +13,13 @@
 # the License.
 
 # String: Networking IP to send to on LAN
-sendIP: '192.168.88.10'
+sendIP: '127.0.0.1'
 
 # Integer: Networking Port to send to on LAN
 sendPORT: 5398
 
 # String: Networking IP to receive from on LAN
-recvIP: '192.168.88.40'
+recvIP: '127.0.0.1'
 
 # Integer: Networking port to receive from on LAN
 recvPORT: 1516
@@ -30,4 +30,4 @@ BUFFER_SIZE: 4096
 
 # String: Interface for which to pull own IP
 # Units: Interface
-INTERFACE: 'eth0'
+INTERFACE: 'lo'

--- a/src/Networking/config/VANET_params.yaml
+++ b/src/Networking/config/VANET_params.yaml
@@ -32,4 +32,4 @@ recvPORT: 1517
 BUFFER_SIZE: 4096
 
 # String: Interface for which to pull own IP
-INTERFACE: 'wlan0'
+INTERFACE: 'wlp0s20f3'

--- a/src/Networking/networking.py
+++ b/src/Networking/networking.py
@@ -129,12 +129,11 @@ class UDP_NET:
 		try:
 			packet = self.sock.recvfrom(self.bufferSize)
 			# checks if received packet is from self
-			if packet[1][0] != self.selfIP:
-				self.logger.info("{}: Received '{}' from {}".format(self.netType, packet[0], packet[1][0]))
-				return packet
-			else:
-				self.logger.debug("{}: Received packet from self @ IP: {}".format(self.netType,packet[1][0]))
+			self.logger.info("{}: Received '{}' from {}:{}".format(self.netType, packet[0], packet[1][0], packet[1][1]))
+			if packet[1][0] == "192.168.0.95" and packet[1][1] == 1517:
+				self.logger.info("Received ack from self, ignoring...")
 				return None
+			return packet
 		except:
 			self.logger.warning("Attempted to receive message from the {} - it may not yet be connected".format(self.netType))
 			if self.print_data:


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

This PR includes changes needed for running the V2X emulator repository on the new CDA 1Tenth laptop.
Specifically, this includes updates to the network parameters and a check to make sure the laptop doesn't ack its own messages.

## Related GitHub Issue

NA

## Related Jira Key

[CF-970](https://usdot-carma.atlassian.net/browse/CF-970)

## Motivation and Context

These changes were made for the TRB setup to ensure that the CDA 1Tenth vehicle was able to successfully execute the port drayage demonstration with V2X Hub in the loop.

## How Has This Been Tested?

This was tested at the TRB booth and, despite the poor network quality, we were still able to validate that the laptop was no longer acking its own messages and message exchange was eventually successful after a significant delay.

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


[CF-970]: https://usdot-carma.atlassian.net/browse/CF-970?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ